### PR TITLE
Add list_packages tool for sub-package discovery

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-const version = "1.0.1"
+const version = "1.1.0"
 
 func main() {
 	transport := flag.String("transport", "stdio", "Transport type: stdio, sse, or http")

--- a/server.go
+++ b/server.go
@@ -50,6 +50,13 @@ Common Usage Patterns:
 
 The documentation is cached for 5 minutes to improve performance.`
 
+const listPackagesDescription = `List all sub-packages under a Go package path.
+Use this to discover the correct import paths for sub-packages when you see types
+referenced from other packages (e.g., seeing "casext.Engine" and needing to find
+which sub-package provides it). Returns each sub-package's import path and synopsis.
+
+Use get_doc to read documentation for a specific package after finding it with this tool.`
+
 type cachedDoc struct {
 	content   string
 	timestamp time.Time
@@ -112,6 +119,19 @@ func newGodocServer() *godocServer {
 		),
 	)
 	s.AddTool(tool, gs.handleGetDoc)
+
+	listTool := mcp.NewTool("list_packages",
+		mcp.WithDescription(listPackagesDescription),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithString("path",
+			mcp.Required(),
+			mcp.Description("Root package import path (e.g., 'net', 'github.com/user/repo') or local path. All sub-packages will be listed."),
+		),
+		mcp.WithString("working_dir",
+			mcp.Description("Working directory for module context. Required for relative paths."),
+		),
+	)
+	s.AddTool(listTool, gs.handleListPackages)
 
 	return gs
 }
@@ -187,6 +207,80 @@ func (gs *godocServer) handleGetDoc(ctx context.Context, request mcp.CallToolReq
 	}
 
 	return mcp.NewToolResultText(result), nil
+}
+
+func (gs *godocServer) handleListPackages(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	pkgPath, err := request.RequireString("path")
+	if err != nil {
+		return mcp.NewToolResultError("path argument is required"), nil
+	}
+
+	workingDir := request.GetString("working_dir", "")
+
+	if workingDir != "" {
+		info, err := os.Stat(workingDir)
+		if err != nil || !info.IsDir() {
+			return mcp.NewToolResultError(fmt.Sprintf("invalid working directory: %s", workingDir)), nil
+		}
+	}
+
+	// Resolve the path.
+	resolvedPath, _, err := validatePath(pkgPath, workingDir)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	pkgPath = resolvedPath
+
+	// Get or create project dir if needed.
+	if workingDir == "" {
+		projDir, err := gs.getOrCreateProject(ctx, pkgPath)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to create temporary project: %v", err)), nil
+		}
+		workingDir = projDir
+	}
+
+	packages, err := gs.listPackages(ctx, workingDir, pkgPath)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	if len(packages) == 0 {
+		return mcp.NewToolResultText(fmt.Sprintf("No sub-packages found under %s", pkgPath)), nil
+	}
+
+	return mcp.NewToolResultText(strings.Join(packages, "\n")), nil
+}
+
+// listPackages runs `go list <path>/...` and returns each package with its doc synopsis.
+func (gs *godocServer) listPackages(ctx context.Context, workingDir, importPath string) ([]string, error) {
+	listCtx, cancel := context.WithTimeout(ctx, cmdTimeout)
+	defer cancel()
+
+	// Use go list -f to get import path and doc synopsis in one call.
+	cmd := exec.CommandContext(listCtx, "go", "list", "-f", "{{.ImportPath}}\t{{.Doc}}", importPath+"/...")
+	cmd.Dir = workingDir
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("go list failed: %w\noutput: %s", err, string(out))
+	}
+
+	var result []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 2)
+		pkg := parts[0]
+		doc := ""
+		if len(parts) == 2 && parts[1] != "" {
+			doc = " - " + parts[1]
+		}
+		result = append(result, pkg+doc)
+	}
+
+	return result, nil
 }
 
 // paginate splits content into pages and returns the requested page with metadata.

--- a/server_test.go
+++ b/server_test.go
@@ -524,6 +524,93 @@ func TestHandleGetDocMissingPath(t *testing.T) {
 	}
 }
 
+func TestListPackagesStdlib(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go not found in PATH")
+	}
+
+	gs := newGodocServer()
+	defer gs.cleanup()
+
+	ctx := context.Background()
+
+	projDir, err := gs.getOrCreateProject(ctx, "net")
+	if err != nil {
+		t.Fatalf("getOrCreateProject: %v", err)
+	}
+
+	packages, err := gs.listPackages(ctx, projDir, "net")
+	if err != nil {
+		t.Fatalf("listPackages: %v", err)
+	}
+
+	if len(packages) < 5 {
+		t.Fatalf("expected at least 5 sub-packages under net, got %d", len(packages))
+	}
+
+	// Should contain net/http somewhere.
+	found := false
+	for _, p := range packages {
+		if strings.HasPrefix(p, "net/http") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected net/http in sub-package list")
+	}
+}
+
+func TestHandleListPackages(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go not found in PATH")
+	}
+
+	gs := newGodocServer()
+	defer gs.cleanup()
+
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "list_packages"
+	req.Params.Arguments = map[string]any{
+		"path": "net",
+	}
+
+	result, err := gs.handleListPackages(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleListPackages returned protocol error: %v", err)
+	}
+
+	if result.IsError {
+		t.Fatalf("handleListPackages returned tool error: %+v", result.Content)
+	}
+
+	for _, c := range result.Content {
+		if tc, ok := c.(mcp.TextContent); ok {
+			if strings.Contains(tc.Text, "net/http") {
+				return // success
+			}
+		}
+	}
+	t.Error("expected 'net/http' in list_packages result")
+}
+
+func TestHandleListPackagesMissingPath(t *testing.T) {
+	gs := newGodocServer()
+
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "list_packages"
+	req.Params.Arguments = map[string]any{}
+
+	result, err := gs.handleListPackages(context.Background(), req)
+	if err != nil {
+		t.Fatalf("returned protocol error: %v", err)
+	}
+
+	if !result.IsError {
+		t.Error("expected tool error for missing path")
+	}
+}
+
 // Test helpers
 
 func makeLines(n int) []string {


### PR DESCRIPTION
Adds a new `list_packages` tool that runs `go list -f` to discover sub-packages under a given import path. Returns each sub-package with its doc synopsis.

Solves the problem described in #9 where LLMs guess incorrect sub-package import paths (e.g. `umoci/casext` instead of `umoci/oci/casext`).

Implemented as a separate tool rather than appending to `get_doc` output to preserve token efficiency — the core pitch of this package.

## Testing

Tested with Claude Code across three models on the exact scenario from #9:

| Model | Prompt | Result |
|-------|--------|--------|
| Opus 4.6 | Find casext.Engine import path in umoci | github.com/opencontainers/umoci/oci/casext |
| Sonnet 4.6 | Same | Same |
| Haiku 4.5 | Same | Same |
| Haiku 4.5 | Find layer operations package | github.com/opencontainers/umoci/oci/layer |
| Haiku 4.5 | Find ASN.1 package under crypto | crypto/x509/pkix + encoding/asn1 |

All models correctly used `list_packages` to discover the right import paths instead of guessing.

18 tests passing, race detector clean.

Closes #9